### PR TITLE
Updated kaniko base image to v1.3.0

### DIFF
--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	// Docker config file path
+	// Docker file path
+	dockerPath       string = "/kaniko/.docker"
 	dockerConfigPath string = "/kaniko/.docker/config.json"
 )
 
@@ -129,10 +130,15 @@ func createDockerCfgFile(username, password, registry string) error {
 		return fmt.Errorf("Registry must be specified")
 	}
 
+	err := os.MkdirAll(dockerPath, 0600)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to create %s directory", dockerPath))
+	}
+
 	authBytes := []byte(fmt.Sprintf("%s:%s", username, password))
 	encodedString := base64.StdEncoding.EncodeToString(authBytes)
 	jsonBytes := []byte(fmt.Sprintf(`{"auths": {"%s": {"auth": "%s"}}}`, registry, encodedString))
-	err := ioutil.WriteFile(dockerConfigPath, jsonBytes, 0644)
+	err = ioutil.WriteFile(dockerConfigPath, jsonBytes, 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to create docker config file")
 	}

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:debug-v0.19.0
+FROM gcr.io/kaniko-project/executor:amd64-v1.3.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v0.19.0
+FROM gcr.io/kaniko-project/executor:arm64-v1.3.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:debug-v0.19.0
+FROM gcr.io/kaniko-project/executor:amd64-v1.3.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/ecr/Dockerfile.linux.arm64
+++ b/docker/ecr/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v0.19.0
+FROM gcr.io/kaniko-project/executor:arm64-v1.3.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:debug-v0.19.0
+FROM gcr.io/kaniko-project/executor:amd64-v1.3.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/gcr/Dockerfile.linux.arm64
+++ b/docker/gcr/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v0.19.0
+FROM gcr.io/kaniko-project/executor:arm64-v1.3.0
 
 ENV HOME /root
 ENV USER root


### PR DESCRIPTION
Updated base version of kaniko image from debug-v0.19.0 to v1.3.0

kaniko version for arm arch was not present for v0.19.0.