### PR TITLE
Fix kaniko-gcr docker file

### DIFF
--- a/cmd/kaniko-gcr/main.go
+++ b/cmd/kaniko-gcr/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// GCR JSON key file path
-	gcrKeyPath     string = "/kaniko/gcr.json"
+	gcrKeyPath     string = "/kaniko/config.json"
 	gcrEnvVariable string = "GOOGLE_APPLICATION_CREDENTIALS"
 )
 

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,7 +1,4 @@
-FROM gcr.io/kaniko-project/executor:amd64-v1.3.0
-
-ENV HOME /root
-ENV USER root
+FROM gcr.io/kaniko-project/executor:v1.3.0
 
 ADD release/linux/amd64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,7 +1,4 @@
-FROM gcr.io/kaniko-project/executor:amd64-v1.3.0
-
-ENV HOME /root
-ENV USER root
+FROM gcr.io/kaniko-project/executor:v1.3.0
 
 ADD release/linux/amd64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,7 +1,4 @@
-FROM gcr.io/kaniko-project/executor:amd64-v1.3.0
-
-ENV HOME /root
-ENV USER root
+FROM gcr.io/kaniko-project/executor:v1.3.0
 
 ADD release/linux/amd64/kaniko-gcr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gcr"]


### PR DESCRIPTION
Fixed kaniko image to v1.3.0 from amd-v1.3.0.
amd-v1.3.0 does not have docker-credential-gcr which is required for uploading to gcr.