### PR TITLE
add skip-tls-verify flag for insecure private registries

### DIFF
--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -94,6 +94,11 @@ func main() {
 			Usage:  "docker password",
 			EnvVar: "PLUGIN_PASSWORD",
 		},
+		cli.BoolFlag {
+			Name: "skip-tls-verify",
+			Usage: "Skip registry tls verify",
+			EnvVar: "PLUGIN_SKIP_TLS_VERIFY",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -116,6 +121,7 @@ func run(c *cli.Context) error {
 			Target:     c.String("target"),
 			Repo:       c.String("repo"),
 			Labels:     c.StringSlice("custom-labels"),
+			SkipTlsVerify: c.Bool("skip-tls-verify"),
 		},
 	}
 	return plugin.Exec()

--- a/kaniko.go
+++ b/kaniko.go
@@ -10,13 +10,14 @@ import (
 type (
 	// Build defines Docker build parameters.
 	Build struct {
-		Dockerfile string   // Docker build Dockerfile
-		Context    string   // Docker build context
-		Tags       []string // Docker build tags
-		Args       []string // Docker build args
-		Target     string   // Docker build target
-		Repo       string   // Docker build repository
-		Labels     []string // Label map
+		Dockerfile    string   // Docker build Dockerfile
+		Context       string   // Docker build context
+		Tags          []string // Docker build tags
+		Args          []string // Docker build args
+		Target        string   // Docker build target
+		Repo          string   // Docker build repository
+		Labels        []string // Label map
+		SkipTlsVerify bool     // Docker skip tls certificate verify for registry
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -55,6 +56,10 @@ func (p Plugin) Exec() error {
 
 	if p.Build.Target != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--target=%s", p.Build.Target))
+	}
+
+	if p.Build.SkipTlsVerify {
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--skip-tls-verify=true"))
 	}
 
 	cmd := exec.Command("/kaniko/executor", cmdArgs...)


### PR DESCRIPTION
Added a new flag to skip https certificate verification for private docker registries.