### PR TITLE
add support for public ecr

### DIFF
--- a/cmd/kaniko-ecr/main.go
+++ b/cmd/kaniko-ecr/main.go
@@ -158,7 +158,7 @@ func setupECRAuth(accessKey, secretKey, registry string) error {
 		}
 	}
 
-	jsonBytes := []byte(fmt.Sprintf(`{"credStore": "ecr-login", "credHelpers": {"%s": "ecr-login"}}`, registry))
+	jsonBytes := []byte(fmt.Sprintf(`{"credStore": "ecr-login", "credHelpers": {"public.ecr.aws": "ecr-login", "%s": "ecr-login"}}`, registry))
 	err := ioutil.WriteFile(dockerConfigPath, jsonBytes, 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to create docker config file")

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.3.0
+FROM gcr.io/kaniko-project/executor:v1.5.2
 
 ADD release/linux/amd64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v1.3.0
+FROM gcr.io/kaniko-project/executor:arm64-v1.5.2
 
 ENV HOME /root
 ENV USER root

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.3.0
+FROM gcr.io/kaniko-project/executor:v1.5.2
 
 ADD release/linux/amd64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/ecr/Dockerfile.linux.arm64
+++ b/docker/ecr/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v1.3.0
+FROM gcr.io/kaniko-project/executor:arm64-v1.5.2
 
 ENV HOME /root
 ENV USER root

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.3.0
+FROM gcr.io/kaniko-project/executor:v1.5.2
 
 ADD release/linux/amd64/kaniko-gcr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gcr"]

--- a/docker/gcr/Dockerfile.linux.arm64
+++ b/docker/gcr/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v1.3.0
+FROM gcr.io/kaniko-project/executor:arm64-v1.5.2
 
 ENV HOME /root
 ENV USER root


### PR DESCRIPTION
Add support for public ecr: [amazon-ecr-credential](https://github.com/awslabs/amazon-ecr-credential-helper#docker)

```json
{
	"credHelpers": {
		"public.ecr.aws": "ecr-login",
		"<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login"
	}
}
```

[https://aws.amazon.com/blogs/containers/amazon-ecr-credential-helper-now-supports-amazon-ecr-public/](https://aws.amazon.com/blogs/containers/amazon-ecr-credential-helper-now-supports-amazon-ecr-public/)

@shubham149 what do you think about this change?