### PR TITLE
Do not require username/password with `no_push: true`

### DIFF
--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -33,7 +33,9 @@ var (
 func main() {
 	// Load env-file if it exists first
 	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
-		godotenv.Load(env)
+		if err := godotenv.Load(env); err != nil {
+			logrus.Fatal(err)
+		}
 	}
 
 	app := cli.NewApp()

--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -147,9 +147,12 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	if !c.Bool("no-push") {
-		err := createDockerCfgFile(c.String("username"), c.String("password"), c.String("registry"))
-		if err != nil {
+	username := c.String("username")
+	noPush := c.Bool("no-push")
+
+	// only setup auth when pushing or credentials are defined
+	if !noPush || username != "" {
+		if err := createDockerCfgFile(username, c.String("password"), c.String("registry")); err != nil {
 			return err
 		}
 	}
@@ -169,7 +172,7 @@ func run(c *cli.Context) error {
 			CacheRepo:     c.String("cache-repo"),
 			CacheTTL:      c.Int("cache-ttl"),
 			DigestFile:    defaultDigestFile,
-			NoPush:        c.Bool("no-push"),
+			NoPush:        noPush,
 			Verbosity:     c.String("verbosity"),
 		},
 		Artifact: kaniko.Artifact{

--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -145,9 +145,11 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	err := createDockerCfgFile(c.String("username"), c.String("password"), c.String("registry"))
-	if err != nil {
-		return err
+	if !c.Bool("no-push") {
+		err := createDockerCfgFile(c.String("username"), c.String("password"), c.String("registry"))
+		if err != nil {
+			return err
+		}
 	}
 
 	plugin := kaniko.Plugin{

--- a/cmd/kaniko-ecr/main.go
+++ b/cmd/kaniko-ecr/main.go
@@ -155,20 +155,22 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	repo := c.String("repo")
-	registry := c.String("registry")
+	if !c.Bool("no-push") {
+		repo := c.String("repo")
+		registry := c.String("registry")
 
-	if err := checkEmptyStringFlags(repo, registry); err != nil {
-		return err
-	}
-
-	if err := setupECRAuth(c.String("access-key"), c.String("secret-key"), registry); err != nil {
-		return err
-	}
-
-	if c.Bool("create-repository") {
-		if err := createRepository(c.String("region"), repo, registry); err != nil {
+		if err := checkEmptyStringFlags(repo, registry); err != nil {
 			return err
+		}
+
+		if err := setupECRAuth(c.String("access-key"), c.String("secret-key"), registry); err != nil {
+			return err
+		}
+
+		if c.Bool("create-repository") {
+			if err := createRepository(c.String("region"), repo, registry); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/kaniko-gcr/main.go
+++ b/cmd/kaniko-gcr/main.go
@@ -131,13 +131,15 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	err := setupGCRAuth(c.String("json-key"))
-	if err != nil {
-		return err
-	}
+	if !c.Bool("no-push") {
+		err := setupGCRAuth(c.String("json-key"))
+		if err != nil {
+			return err
+		}
 
-	if c.String("repo") == "" {
-		return fmt.Errorf("repo must be specified")
+		if c.String("repo") == "" {
+			return fmt.Errorf("repo must be specified")
+		}
 	}
 
 	plugin := kaniko.Plugin{

--- a/cmd/kaniko-gcr/main.go
+++ b/cmd/kaniko-gcr/main.go
@@ -29,7 +29,9 @@ var (
 func main() {
 	// Load env-file if it exists first
 	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
-		godotenv.Load(env)
+		if err := godotenv.Load(env); err != nil {
+			logrus.Fatal(err)
+		}
 	}
 
 	app := cli.NewApp()

--- a/cmd/kaniko-gcr/main.go
+++ b/cmd/kaniko-gcr/main.go
@@ -133,14 +133,13 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	if !c.Bool("no-push") {
-		err := setupGCRAuth(c.String("json-key"))
-		if err != nil {
-			return err
-		}
+	noPush := c.Bool("no-push")
+	jsonKey := c.String("json-key")
 
-		if c.String("repo") == "" {
-			return fmt.Errorf("repo must be specified")
+	// only setup auth when pushing or credentials are defined
+	if !noPush || jsonKey != "" {
+		if err := setupGCRAuth(jsonKey); err != nil {
+			return err
 		}
 	}
 
@@ -158,7 +157,7 @@ func run(c *cli.Context) error {
 			CacheRepo:    fmt.Sprintf("%s/%s", c.String("registry"), c.String("cache-repo")),
 			CacheTTL:     c.Int("cache-ttl"),
 			DigestFile:   defaultDigestFile,
-			NoPush:       c.Bool("no-push"),
+			NoPush:       noPush,
 			Verbosity:    c.String("verbosity"),
 		},
 		Artifact: kaniko.Artifact{

--- a/kaniko.go
+++ b/kaniko.go
@@ -80,15 +80,15 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Build.SkipTlsVerify {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--skip-tls-verify=true"))
+		cmdArgs = append(cmdArgs, "--skip-tls-verify=true")
 	}
 
 	if p.Build.SnapshotMode != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--snapshotMode=%s", p.Build.SnapshotMode))
 	}
 
-	if p.Build.EnableCache == true {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--cache=true"))
+	if p.Build.EnableCache {
+		cmdArgs = append(cmdArgs, "--cache=true")
 
 		if p.Build.CacheRepo != "" {
 			cmdArgs = append(cmdArgs, fmt.Sprintf("--cache-repo=%s", p.Build.CacheRepo))
@@ -104,7 +104,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Build.NoPush {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--no-push"))
+		cmdArgs = append(cmdArgs, "--no-push")
 	}
 
 	if p.Build.Verbosity != "" {

--- a/kaniko.go
+++ b/kaniko.go
@@ -47,7 +47,7 @@ type (
 
 // Exec executes the plugin step
 func (p Plugin) Exec() error {
-	if p.Build.Repo == "" {
+	if !p.Build.NoPush && p.Build.Repo == "" {
 		return fmt.Errorf("repository name to publish image must be specified")
 	}
 
@@ -61,8 +61,10 @@ func (p Plugin) Exec() error {
 	}
 
 	// Set the destination repository
-	for _, tag := range p.Build.Tags {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--destination=%s:%s", p.Build.Repo, tag))
+	if !p.Build.NoPush {
+		for _, tag := range p.Build.Tags {
+			cmdArgs = append(cmdArgs, fmt.Sprintf("--destination=%s:%s", p.Build.Repo, tag))
+		}
 	}
 	// Set the build arguments
 	for _, arg := range p.Build.Args {


### PR DESCRIPTION
This updates all binaries and the plugin to skip authentication mechanisms when `no_push: true`. This allows pipelines to perform builds without requiring secrets, which can be useful during `pull_request` events, for example.

This was tested with the following public image
```
---
kind: pipeline
name: default

steps:
  - name: publish
    image: colinhoglund/kaniko-ecr
    settings:
      no_push: true
```

There is also a commit with a bit of linting.