### PR TITLE
Support Docker Hub credentials when pulling with kaniko-ecr

### DIFF
--- a/cmd/kaniko-ecr/main_test.go
+++ b/cmd/kaniko-ecr/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/drone/drone-kaniko/pkg/docker"
+)
+
+func TestCreateDockerConfig(t *testing.T) {
+	got, err := createDockerConfig(
+		"docker-username",
+		"docker-password",
+		"access-key",
+		"secret-key",
+		"ecr-registry",
+		false,
+	)
+	if err != nil {
+		t.Error("failed to create docker config")
+	}
+
+	want := docker.NewConfig()
+	want.SetAuth(docker.RegistryV1, "docker-username", "docker-password")
+	want.SetCredHelper(docker.RegistryECRPublic, "ecr-login")
+	want.SetCredHelper("ecr-registry", "ecr-login")
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("not equal:\n  want: %#v\n   got: %#v", want, got)
+	}
+}

--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -1,0 +1,34 @@
+package docker
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+type (
+	Auth struct {
+		Auth string `json:"auth"`
+	}
+
+	Config struct {
+		Auths       map[string]Auth   `json:"auths"`
+		CredHelpers map[string]string `json:"credHelpers"`
+	}
+)
+
+func NewConfig() *Config {
+	return &Config{
+		Auths:       map[string]Auth{},
+		CredHelpers: map[string]string{},
+	}
+}
+
+func (c *Config) SetAuth(registry, username, password string) {
+	authBytes := []byte(fmt.Sprintf("%s:%s", username, password))
+	encodedString := base64.StdEncoding.EncodeToString(authBytes)
+	c.Auths[registry] = Auth{Auth: encodedString}
+}
+
+func (c *Config) SetCredHelper(registry, helper string) {
+	c.CredHelpers[registry] = helper
+}

--- a/pkg/docker/config_test.go
+++ b/pkg/docker/config_test.go
@@ -1,0 +1,25 @@
+package docker
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	c := NewConfig()
+
+	c.SetAuth(RegistryV1, "test", "password")
+	c.SetCredHelper(RegistryECRPublic, "ecr-login")
+
+	bytes, err := json.Marshal(c)
+	if err != nil {
+		t.Error("json marshal failed")
+	}
+
+	want := `{"auths":{"https://index.docker.io/v1/":{"auth":"dGVzdDpwYXNzd29yZA=="}},"credHelpers":{"public.ecr.aws":"ecr-login"}}`
+	got := string(bytes)
+
+	if want != got {
+		t.Errorf("unexpected json output:\n  want: %s\n   got: %s", want, got)
+	}
+}

--- a/pkg/docker/constants.go
+++ b/pkg/docker/constants.go
@@ -1,0 +1,7 @@
+package docker
+
+const (
+	RegistryV1        string = "https://index.docker.io/v1/"
+	RegistryV2        string = "https://index.docker.io/v2/"
+	RegistryECRPublic string = "public.ecr.aws"
+)


### PR DESCRIPTION
This adds support for docker credentials to be passed to the `kaniko-ecr` plugin to avoid hitting rate limits when pulling from docker hub. Configuration is setup similar to https://github.com/drone-plugins/drone-docker.

This also removes the `"credStore": "ecr-login"` configuration, which seems to be a typo for `credsStore` and is also unnecessary with the `credHelpers` configuration.

A compiled version of this has been pushed to `colinhoglund/kaniko-ecr:docker-pass`