### PR TITLE
updated kaniko executer version to 1.6.0 to solve the docker registry authentication.

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.5.2
+FROM gcr.io/kaniko-project/executor:v1.6.0
 
 ADD release/linux/amd64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v1.5.2
+FROM gcr.io/kaniko-project/executor:arm64-v1.6.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.5.2
+FROM gcr.io/kaniko-project/executor:v1.6.0
 
 ADD release/linux/amd64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/ecr/Dockerfile.linux.arm64
+++ b/docker/ecr/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v1.5.2
+FROM gcr.io/kaniko-project/executor:arm64-v1.6.0
 
 ENV HOME /root
 ENV USER root

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.5.2
+FROM gcr.io/kaniko-project/executor:v1.6.0
 
 ADD release/linux/amd64/kaniko-gcr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gcr"]

--- a/docker/gcr/Dockerfile.linux.arm64
+++ b/docker/gcr/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:arm64-v1.5.2
+FROM gcr.io/kaniko-project/executor:arm64-v1.6.0
 
 ENV HOME /root
 ENV USER root


### PR DESCRIPTION
For some reason the kaniko executer v1.5.2 is unable to complete the docker registry authentication check.

It will fail with the error during the auth check:

```
/kaniko/executor --dockerfile=Dockerfile --context=dir://. --destination=docker.mydomainhere.com/test/project:latest --digest-file=/kaniko/digest-file
error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "docker.mydomainhere.com/test/project:latest": POST https://docker.mydomainhere.com/v2/test/project/blobs/uploads/: UNAUTHORIZED: authentication required; [map[Action:pull Class: Name:test/project Type:repository] map[Action:push Class: Name:test/project Type:repository]]
exit status 1
```

With the version bump, authentication with docker repository seems to be working again. Unfortunately, the changelog from kaniko does not note any issue or fix for this problem between v1.5.2 and v1.6.0