### PR TITLE
Unify registry+repo behavior between plugins

### DIFF
--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"github.com/pkg/errors"
@@ -184,7 +185,7 @@ func run(c *cli.Context) error {
 		},
 		Artifact: kaniko.Artifact{
 			Tags:         c.StringSlice("tags"),
-			Repo:         c.String("repo"),
+			Repo:         buildRepo(c.String("registry"), c.String("repo")),
 			Registry:     c.String("registry"),
 			ArtifactFile: c.String("artifact-file"),
 			RegistryType: artifact.Docker,
@@ -224,4 +225,18 @@ func createDockerCfgFile(username, password, registry string) error {
 		return errors.Wrap(err, "failed to create docker config file")
 	}
 	return nil
+}
+
+func buildRepo(registry, repo string) string {
+	if registry == "" {
+		// No custom registry, just return the repo name
+		return repo
+	}
+	if strings.HasPrefix(repo, registry + "/") {
+		// Repo already includes the registry prefix
+		// For backward compatibility, we won't add the prefix again.
+		return repo
+	}
+	// Prefix the repo with the registry
+	return registry + "/" + repo
 }

--- a/cmd/kaniko-docker/main_test.go
+++ b/cmd/kaniko-docker/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func Test_buildRepo(t *testing.T) {
+	tests := []struct {
+		name     string
+		registry string
+		repo     string
+		want     string
+	}{
+		{
+			name: "dockerhub",
+			repo: "golang",
+			want: "golang",
+		},
+		{
+			name:     "internal",
+			registry: "artifactory.example.com",
+			repo:     "service",
+			want:     "artifactory.example.com/service",
+		},
+		{
+			name:     "backward_compatibility",
+			registry: "artifactory.example.com",
+			repo:     "artifactory.example.com/service",
+			want:     "artifactory.example.com/service",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildRepo(tt.registry, tt.repo); got != tt.want {
+				t.Errorf("buildRepo(%q, %q) = %v, want %v", tt.registry, tt.repo, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I noticed this when trying to do a bulk change of our repositories to use the upstreaam `plugins/kaniko{,-ecr,-gcr}` -- they don't behave the same when you pass

```
settings:
  registry: example.com
  repo: bar
```

Specifically:
* kaniko will try `index.docker.io/bar`
* kaniko-ecr and -gcr will try `example.com/bar` (which is the behavior I would expect)

So, with the current state, our non-ECR / non-GCR images have to repeat the registry in the settings block, and they are inconsistent with the internal one.

This PR allows use of either the "compatible" setting block like

```
settings:
  registry: example.com
  repo: bar
```

or the previously required

```
settings:
  registry: example.com
  repo: example.com/bar
```

with the same results of trying to push to `example.com/bar`

This change attempts to retain backward compatibility to avoid breaking anyone.