### PR TITLE
Fix "--cache-ttl" flag missing unit in duration

### DIFF
--- a/kaniko.go
+++ b/kaniko.go
@@ -143,7 +143,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Build.CacheTTL != 0 {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--cache-ttl=%d", p.Build.CacheTTL))
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--cache-ttl=%dh", p.Build.CacheTTL))
 	}
 
 	if p.Build.DigestFile != "" {


### PR DESCRIPTION
[Google Cloud document: Using Kaniko cache](https://cloud.google.com/build/docs/kaniko-cache#configuring_the_cache_expiration_time)

> The syntax is --cache-ttl=XXh where XX is time in hours. For example, --cache-ttl=6h sets the cache expiration to 6 hours. If you run builds using the gcloud builds submit --tag [IMAGE] command, the default value of the --cache-ttl flag is 6 hours. If you are using the Kaniko executor image directly, the default value is 2 weeks.