### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ With expanded tagging enabled, semantic versions can be passed to PLUGIN_TAGS di
 ```console
 docker run --rm \
     -e PLUGIN_TAGS=v1.2.3,latest \
-    -e PLUGIN_EXPAND_TAGS=true \
+    -e PLUGIN_EXPAND_TAG=true \
     -v $(pwd):/drone \
     -w /drone \
     plugins/kaniko:linux-amd64
@@ -73,13 +73,13 @@ PLUGIN_TAGS=1,1.2,1.2.3,latest
 
 This allows for passing `$DRONE_TAG` directly as a tag for repos that use [semver](https://semver.org) tags.
 
-To avoid confusion between repo tags and image tags, `PLUGIN_EXPAND_TAGS` also recognizes a semantic version
+To avoid confusion between repo tags and image tags, `PLUGIN_EXPAND_TAG` also recognizes a semantic version
 without the `v` prefix.  As such, the following is also equivalent to the above:
 
 ```console
 docker run --rm \
     -e PLUGIN_TAGS=1.2.3,latest \
-    -e PLUGIN_EXPAND_TAGS=true \
+    -e PLUGIN_EXPAND_TAG=true \
     -v $(pwd):/drone \
     -w /drone \
     plugins/kaniko:linux-amd64


### PR DESCRIPTION
From de43f3afb698f9e141145b8715cad396ac08f3e6, both the code and the
commit message used singular form of expand_tag, but the example in the
README used the plural form of expand_tags. Based on that I assume the
singular form was the intention and the plural form in the README was a
typo (the plural form does not work because the code only checks for the
singular form env var).


