### PR TITLE
fix: Build.Repo and Build.CacheRepo now uses buildRepo()

### DIFF
--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -206,7 +206,7 @@ func run(c *cli.Context) error {
 			SkipTlsVerify:   c.Bool("skip-tls-verify"),
 			SnapshotMode:    c.String("snapshot-mode"),
 			EnableCache:     c.Bool("enable-cache"),
-			CacheRepo:       c.String("cache-repo"),
+			CacheRepo:       buildRepo(c.String("registry"), c.String("cache-repo")),
 			CacheTTL:        c.Int("cache-ttl"),
 			DigestFile:      defaultDigestFile,
 			NoPush:          noPush,

--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -262,6 +262,8 @@ func buildRepo(registry, repo string) string {
 		// No custom registry, just return the repo name
 		return repo
 	}
+	// Trim off trailing slash to prevent double slash when combining with repo
+	registry = strings.TrimSuffix(registry, "/")
 	if strings.HasPrefix(repo, registry+"/") {
 		// Repo already includes the registry prefix
 		// For backward compatibility, we won't add the prefix again.

--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -201,7 +201,7 @@ func run(c *cli.Context) error {
 			ExpandTag:       c.Bool("expand-tag"),
 			Args:            c.StringSlice("args"),
 			Target:          c.String("target"),
-			Repo:            c.String("repo"),
+			Repo:            buildRepo(c.String("registry"), c.String("repo")),
 			Labels:          c.StringSlice("custom-labels"),
 			SkipTlsVerify:   c.Bool("skip-tls-verify"),
 			SnapshotMode:    c.String("snapshot-mode"),


### PR DESCRIPTION
Fixed assignment of Build.Repo and Build.CacheRepo so it not only contains the specified repo, but also registry by using buildRepo().
This required for pushing images to private repositories.