### PR TITLE
Publish plugin with latest kaniko 1.8.0 image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,6 +60,56 @@ steps:
       exclude:
       - pull_request
 
+- name: docker-kaniko-v1-8
+  image: plugins/docker
+  settings:
+    repo: plugins/kaniko
+    auto_tag: true
+    auto_tag_suffix: linux-amd64-kaniko1.8.0
+    daemon_off: false
+    dockerfile: docker/docker/Dockerfile.linux.amd64.kaniko1.8.0
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    event:
+      exclude:
+      - pull_request
+
+- name: gcr-kaniko-v1-8
+  image: plugins/docker
+  settings:
+    repo: plugins/kaniko-gcr
+    auto_tag: true
+    auto_tag_suffix: linux-amd64-kaniko1.8.0
+    daemon_off: false
+    dockerfile: docker/gcr/Dockerfile.linux.amd64.kaniko1.8.0
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    event:
+      exclude:
+      - pull_request
+
+- name: ecr-kaniko-v1-8
+  image: plugins/docker
+  settings:
+    repo: plugins/kaniko-ecr
+    auto_tag: true
+    auto_tag_suffix: linux-amd64-kaniko1.8.0
+    daemon_off: false
+    dockerfile: docker/ecr/Dockerfile.linux.amd64.kaniko1.8.0
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    event:
+      exclude:
+      - pull_request
 ---
 kind: pipeline
 type: docker
@@ -103,6 +153,60 @@ steps:
     password:
       from_secret: docker_password
     spec: docker/ecr/manifest.tmpl
+    username:
+      from_secret: docker_username
+
+trigger:
+  ref:
+  - refs/heads/main
+  - "refs/tags/**"
+
+depends_on:
+- default
+
+---
+kind: pipeline
+type: docker
+name: notifications-docker-kaniko1-8
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: manifest-docker
+  pull: always
+  image: plugins/manifest
+  settings:
+    auto_tag: true
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: docker/docker/manifest-kaniko1.8.0.tmpl
+    username:
+      from_secret: docker_username
+
+- name: manifest-gcr
+  pull: always
+  image: plugins/manifest
+  settings:
+    auto_tag: true
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: docker/gcr/manifest-kaniko1.8.0.tmpl
+    username:
+      from_secret: docker_username
+
+- name: manifest-ecr
+  pull: always
+  image: plugins/manifest
+  settings:
+    auto_tag: true
+    ignore_missing: true
+    password:
+      from_secret: docker_password
+    spec: docker/ecr/manifest-kaniko1.8.0.tmpl
     username:
       from_secret: docker_username
 

--- a/docker/docker/Dockerfile.linux.amd64.kaniko1.8.0
+++ b/docker/docker/Dockerfile.linux.amd64.kaniko1.8.0
@@ -1,0 +1,4 @@
+FROM gcr.io/kaniko-project/executor:v1.8.0
+
+ADD release/linux/amd64/kaniko-docker /kaniko/
+ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/docker/manifest-kaniko1.8.0.tmpl
+++ b/docker/docker/manifest-kaniko1.8.0.tmpl
@@ -1,0 +1,13 @@
+image: plugins/kaniko:{{#if build.tag}}{{trimPrefix "v" build.tag}}-kaniko1.8.0{{else}}latest-kaniko1.8.0{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: plugins/kaniko:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64-kaniko1.8.0
+    platform:
+      architecture: amd64
+      os: linux

--- a/docker/ecr/Dockerfile.linux.amd64.kaniko1.8.0
+++ b/docker/ecr/Dockerfile.linux.amd64.kaniko1.8.0
@@ -1,0 +1,4 @@
+FROM gcr.io/kaniko-project/executor:v1.8.0
+
+ADD release/linux/amd64/kaniko-ecr /kaniko/
+ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/ecr/manifest-kaniko1.8.0.tmpl
+++ b/docker/ecr/manifest-kaniko1.8.0.tmpl
@@ -1,0 +1,13 @@
+image: plugins/ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-kaniko1.8.0{{else}}latest-kaniko1.8.0{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: plugins/ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64-kaniko1.8.0
+    platform:
+      architecture: amd64
+      os: linux

--- a/docker/gcr/Dockerfile.linux copy.amd64
+++ b/docker/gcr/Dockerfile.linux copy.amd64
@@ -1,0 +1,4 @@
+FROM gcr.io/kaniko-project/executor:v1.8.0
+
+ADD release/linux/amd64/kaniko-gcr /kaniko/
+ENTRYPOINT ["/kaniko/kaniko-gcr"]

--- a/docker/gcr/manifest-kaniko1.8.0.tmpl
+++ b/docker/gcr/manifest-kaniko1.8.0.tmpl
@@ -1,0 +1,13 @@
+image: plugins/gcr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-kaniko1.8.0{{else}}latest-kaniko1.8.0{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: plugins/gcr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64-kaniko1.8.0
+    platform:
+      architecture: amd64
+      os: linux


### PR DESCRIPTION
Kaniko 1.6.0 will still remain the default version. With this change, it will publish an extra docker image of the plugin using kaniko version 1.8.0 