### PR TITLE
Making prepend of registry url to repo name optional

### DIFF
--- a/cmd/kaniko-docker/main_test.go
+++ b/cmd/kaniko-docker/main_test.go
@@ -29,7 +29,7 @@ func Test_buildRepo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := buildRepo(tt.registry, tt.repo); got != tt.want {
+			if got := buildRepo(tt.registry, tt.repo, true); got != tt.want {
 				t.Errorf("buildRepo(%q, %q) = %v, want %v", tt.registry, tt.repo, got, tt.want)
 			}
 		})


### PR DESCRIPTION
PR #40 added prepending of registry url to repo name. But there are some missing cases present:
1. If registry URL is public dockerhub, the full repo name: index.docker.io//: but this change generates repo name as https://index.docker.io/v1/<myrepo>/<myimage>:latest. Also, it needs to handle repo's without dockerhubUsr e.g. alpine image.
2. https:// is usually present in the registry url but should not be mentioned in the repo name.
3. Some registry url's include version number which should not be present in repo name.

Hence, this will make prepending of registry url to repo name optional by introducing a field expand_repo which is by default false.