### PR TITLE
Kaniko ecr v1.5.0 0.1.0

### DIFF
--- a/cmd/kaniko-ecr/main_test.go
+++ b/cmd/kaniko-ecr/main_test.go
@@ -13,7 +13,6 @@ func TestCreateDockerConfig(t *testing.T) {
 		"docker-password",
 		"access-key",
 		"secret-key",
-		"ecr-registry",
 		false,
 	)
 	if err != nil {
@@ -22,8 +21,6 @@ func TestCreateDockerConfig(t *testing.T) {
 
 	want := docker.NewConfig()
 	want.SetAuth(docker.RegistryV1, "docker-username", "docker-password")
-	want.SetCredHelper(docker.RegistryECRPublic, "ecr-login")
-	want.SetCredHelper("ecr-registry", "ecr-login")
 
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("not equal:\n  want: %#v\n   got: %#v", want, got)

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM gcr.io/kaniko-project/executor:v1.6.0
+FROM gcr.io/kaniko-project/executor:v1.8.1
 
 ADD release/linux/amd64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]


### PR DESCRIPTION
This upgrade the kaniko-executor version to 1.8.1 for support for the Instance Metadata Service v2. 

The kaniko-executor now internalizes the amazon-ecr-credentials helper. This removes the need for credHelpers docker config blocks but also means that only one set of IAM credentials can be used per call to the plugin. The IAM credentials passed to kaniko-ecr will needs pull permissions on any ecr registries used in the Dockerfile and push permissions to the registry it is publishing to. 

Credentials are sourced from the environment and the executor respects the aws sdk environment variables. If no credentials are provided, the plugin can default to an EC2 Instance profile or a federated role, i.e.  IRSA, via environment variables. 