### PR TITLE
golang image upgrade to 1.18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ name: default
 
 steps:
 - name: build
-  image: golang:1.17.8
+  image: golang:1.18
   commands:
   - go test ./...
   - sh scripts/build.sh

--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,4 @@ require (
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 )
 
-go 1.17
+go 1.18


### PR DESCRIPTION
The automation suite for drone-kaniko is passing successfully with the new updated images.

Reason for image update:

Security Reference Ticket - https://harness.atlassian.net/browse/SECAPP-258
To meet federal requirements for storing harness images.