### PR TITLE
Add beta testcase for clarity, coverage, and regression prevention

### DIFF
--- a/kaniko_test.go
+++ b/kaniko_test.go
@@ -100,7 +100,16 @@ func TestBuild_AutoTags(t *testing.T) {
 			},
 		},
 		{
-			name:          "tag push",
+			name:          "beta tag push",
+			repoBranch:    "master",
+			commitRef:     "refs/tags/v1.0.0-beta.1",
+			autoTagSuffix: "",
+			expectedTags: []string{
+				"1.0.0-beta.1",
+			},
+		},
+		{
+			name:          "tag push with suffix",
 			repoBranch:    "master",
 			commitRef:     "refs/tags/v1.0.0",
 			autoTagSuffix: "linux-amd64",


### PR DESCRIPTION
We rely on this behavior, and so we added a test case to make sure it was working as we expected.

It seems worth contributing so that anyone else can easily check and see the behavior, and so that it never gets accidentally broken in the future.