### PR TITLE
Fix Flag --customPlatform is deprecated

### DIFF
--- a/kaniko.go
+++ b/kaniko.go
@@ -214,7 +214,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Build.Platform != "" {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--customPlatform=%s", p.Build.Platform))
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--custom-platform=%s", p.Build.Platform))
 	}
 
 	if p.Build.SkipUnusedStages {
@@ -224,7 +224,7 @@ func (p Plugin) Exec() error {
 	if p.Build.TarPath != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--tar-path=%s", p.Build.TarPath))
 	}
-	
+
 	cmd := exec.Command("/kaniko/executor", cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
When I try to use the platform parameter, the following prompt appears：

`/kaniko/executor ....... --customPlatform=linux/amd64
time="2023-05-16T02:15:32Z" level=warning msg="Flag --customPlatform is deprecated. Use: --custom-platform"`

This has been fixed