### PR TITLE
Add support for kaniko executor single-snapshot flag

### DIFF
--- a/cmd/kaniko-acr/main.go
+++ b/cmd/kaniko-acr/main.go
@@ -152,6 +152,11 @@ func main() {
 			EnvVar: "CLIENT_ID",
 		},
 		cli.StringFlag{
+			Name:   "single-snapshot",
+			Usage:  "Takes a single snapshot of the filesystem at the end of the build, only that will be appended to the base image",
+			EnvVar: "PLUGIN_SINGLE_SNAPSHOT",
+		},
+		cli.StringFlag{
 			Name:   "snapshot-mode",
 			Usage:  "Specify one of full, redo or time as snapshot mode",
 			EnvVar: "PLUGIN_SNAPSHOT_MODE",
@@ -245,6 +250,7 @@ func run(c *cli.Context) error {
 			Repo:             c.String("repo"),
 			Mirrors:          c.StringSlice("registry-mirrors"),
 			Labels:           c.StringSlice("custom-labels"),
+			SingleSnapshot:   c.Bool("single-snapshot"),
 			SnapshotMode:     c.String("snapshot-mode"),
 			EnableCache:      c.Bool("enable-cache"),
 			CacheRepo:        fmt.Sprintf("%s/%s", c.String("registry"), c.String("cache-repo")),

--- a/cmd/kaniko-docker/main.go
+++ b/cmd/kaniko-docker/main.go
@@ -147,6 +147,11 @@ func main() {
 			EnvVar: "PLUGIN_SKIP_TLS_VERIFY",
 		},
 		cli.StringFlag{
+			Name:   "single-snapshot",
+			Usage:  "Takes a single snapshot of the filesystem at the end of the build, only that will be appended to the base image",
+			EnvVar: "PLUGIN_SINGLE_SNAPSHOT",
+		},
+		cli.StringFlag{
 			Name:   "snapshot-mode",
 			Usage:  "Specify one of full, redo or time as snapshot mode",
 			EnvVar: "PLUGIN_SNAPSHOT_MODE",
@@ -241,6 +246,7 @@ func run(c *cli.Context) error {
 			Mirrors:          c.StringSlice("registry-mirrors"),
 			Labels:           c.StringSlice("custom-labels"),
 			SkipTlsVerify:    c.Bool("skip-tls-verify"),
+			SingleSnapshot:   c.Bool("single-snapshot"),
 			SnapshotMode:     c.String("snapshot-mode"),
 			EnableCache:      c.Bool("enable-cache"),
 			CacheRepo:        buildRepo(c.String("registry"), c.String("cache-repo"), c.Bool("expand-repo")),

--- a/cmd/kaniko-ecr/main.go
+++ b/cmd/kaniko-ecr/main.go
@@ -170,6 +170,11 @@ func main() {
 			EnvVar: "PLUGIN_SECRET_KEY",
 		},
 		cli.StringFlag{
+			Name:   "single-snapshot",
+			Usage:  "Takes a single snapshot of the filesystem at the end of the build, only that will be appended to the base image",
+			EnvVar: "PLUGIN_SINGLE_SNAPSHOT",
+		},
+		cli.StringFlag{
 			Name:   "assume-role",
 			Usage:  "Assume a role",
 			EnvVar: "PLUGIN_ASSUME_ROLE",
@@ -316,6 +321,7 @@ func run(c *cli.Context) error {
 			Repo:             fmt.Sprintf("%s/%s", c.String("registry"), c.String("repo")),
 			Mirrors:          c.StringSlice("registry-mirrors"),
 			Labels:           c.StringSlice("custom-labels"),
+			SingleSnapshot:   c.Bool("single-snapshot"),
 			SnapshotMode:     c.String("snapshot-mode"),
 			EnableCache:      c.Bool("enable-cache"),
 			CacheRepo:        fmt.Sprintf("%s/%s", c.String("registry"), c.String("cache-repo")),

--- a/cmd/kaniko-gar/main.go
+++ b/cmd/kaniko-gar/main.go
@@ -120,6 +120,11 @@ func main() {
 			EnvVar: "PLUGIN_JSON_KEY",
 		},
 		cli.StringFlag{
+			Name:   "single-snapshot",
+			Usage:  "Takes a single snapshot of the filesystem at the end of the build, only that will be appended to the base image",
+			EnvVar: "PLUGIN_SINGLE_SNAPSHOT",
+		},
+		cli.StringFlag{
 			Name:   "snapshot-mode",
 			Usage:  "Specify one of full, redo or time as snapshot mode",
 			EnvVar: "PLUGIN_SNAPSHOT_MODE",
@@ -199,6 +204,7 @@ func run(c *cli.Context) error {
 			Repo:             fmt.Sprintf("%s/%s", c.String("registry"), c.String("repo")),
 			Mirrors:          c.StringSlice("registry-mirrors"),
 			Labels:           c.StringSlice("custom-labels"),
+			SingleSnapshot:   c.Bool("single-snapshot"),
 			SnapshotMode:     c.String("snapshot-mode"),
 			EnableCache:      c.Bool("enable-cache"),
 			CacheRepo:        fmt.Sprintf("%s/%s", c.String("registry"), c.String("cache-repo")),

--- a/cmd/kaniko-gcr/main.go
+++ b/cmd/kaniko-gcr/main.go
@@ -121,6 +121,11 @@ func main() {
 			EnvVar: "PLUGIN_JSON_KEY",
 		},
 		cli.StringFlag{
+			Name:   "single-snapshot",
+			Usage:  "Takes a single snapshot of the filesystem at the end of the build, only that will be appended to the base image",
+			EnvVar: "PLUGIN_SINGLE_SNAPSHOT",
+		},
+		cli.StringFlag{
 			Name:   "snapshot-mode",
 			Usage:  "Specify one of full, redo or time as snapshot mode",
 			EnvVar: "PLUGIN_SNAPSHOT_MODE",
@@ -200,6 +205,7 @@ func run(c *cli.Context) error {
 			Repo:             fmt.Sprintf("%s/%s", c.String("registry"), c.String("repo")),
 			Mirrors:          c.StringSlice("registry-mirrors"),
 			Labels:           c.StringSlice("custom-labels"),
+			SingleSnapshot:   c.Bool("single-snapshot"),
 			SnapshotMode:     c.String("snapshot-mode"),
 			EnableCache:      c.Bool("enable-cache"),
 			CacheRepo:        fmt.Sprintf("%s/%s", c.String("registry"), c.String("cache-repo")),

--- a/kaniko.go
+++ b/kaniko.go
@@ -30,6 +30,7 @@ type (
 		Mirrors          []string // Docker repository mirrors
 		Labels           []string // Label map
 		SkipTlsVerify    bool     // Docker skip tls certificate verify for registry
+		SingleSnapshot   bool     // Kaniko single snapshot mode
 		SnapshotMode     string   // Kaniko snapshot mode
 		EnableCache      bool     // Whether to enable kaniko cache
 		CacheRepo        string   // Remote repository that will be used to store cached layers
@@ -189,6 +190,10 @@ func (p Plugin) Exec() error {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--snapshotMode=%s", p.Build.SnapshotMode))
 	}
 
+	if p.Build.SingleSnapshot {
+		cmdArgs = append(cmdArgs, "--single-snapshot=true")
+	}
+
 	if p.Build.EnableCache {
 		cmdArgs = append(cmdArgs, "--cache=true")
 
@@ -224,7 +229,7 @@ func (p Plugin) Exec() error {
 	if p.Build.TarPath != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--tar-path=%s", p.Build.TarPath))
 	}
-	
+
 	cmd := exec.Command("/kaniko/executor", cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This is a rebase/update of #34 