### PR TITLE
add validations on response from /subscriptions API in ACR

### DIFF
--- a/cmd/kaniko-acr/main.go
+++ b/cmd/kaniko-acr/main.go
@@ -432,6 +432,15 @@ func getPublicUrl(token, registryUrl, subscriptionId string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to send request for getting container registry setting")
 	}
+
+	if len(response.Value) == 0 {
+		return "", errors.New("did not receive any registry information from /subscriptions API")
+	}
+
+	if response.Value[0].ID == "" {
+		return "", errors.New("received empty registry ID from /subscriptions API")
+	}
+
 	return finalUrl + encodeParam(response.Value[0].ID), nil
 }
 


### PR DESCRIPTION
Adds validations to error out gracefully in case no elements exist in response.Value from the /subscriptions API response