### PR TITLE
[CI-13182]: Use snapshot-mode instead of snapshotMode

### DIFF
--- a/kaniko.go
+++ b/kaniko.go
@@ -222,7 +222,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Build.SnapshotMode != "" {
-		cmdArgs = append(cmdArgs, fmt.Sprintf("--snapshotMode=%s", p.Build.SnapshotMode))
+		cmdArgs = append(cmdArgs, fmt.Sprintf("--snapshot-mode=%s", p.Build.SnapshotMode))
 	}
 
 	if p.Build.EnableCache {


### PR DESCRIPTION
The kaniko flag `snapshotMode` is deprecated in favor of `snapshot-mode`. The default value of `snapshot-mode` is `full`. As a result, the `optimize` flag set in Harness CI's `BuildAndPushToDocker` steps doesn't behave as expected because the `full` mode triggers a full filesystem scan which is slow. The `optimize` flag in Harness translates to `snapshot-mode=redo` which means only filesystem deltas are compared which is much faster. 

This change fixes the flag name being sent to Kaniko executor. I verified that the executor present in the current version already supports this flag as shown below:

```
mantri@harness% docker run -it --entrypoint /kaniko/executor plugins/kaniko:1.8.10 --help | grep snapshot-mode
      --snapshot-mode string                      Change the file attributes inspected during snapshotting (default "full")
      --snapshotMode string                       This flag is deprecated. Please use '--snapshot-mode'.
```


