### PR TITLE
upgrade kaniko version for chmod on ADD and COPY

### DIFF
--- a/docker/acr/Dockerfile.linux.amd64
+++ b/docker/acr/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/amd64/kaniko-acr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-acr"]

--- a/docker/acr/Dockerfile.linux.arm64
+++ b/docker/acr/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
 ENV HOME /root
 ENV USER root
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/arm64/kaniko-acr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-acr"]

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/amd64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
 ENV HOME /root
 ENV USER root
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/arm64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/amd64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/ecr/Dockerfile.linux.arm64
+++ b/docker/ecr/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
 ENV HOME /root
 ENV USER root
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 
 ADD release/linux/arm64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/gar/Dockerfile.linux.amd64
+++ b/docker/gar/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/amd64/kaniko-gar /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gar"]

--- a/docker/gar/Dockerfile.linux.arm64
+++ b/docker/gar/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
 ENV HOME /root
 ENV USER root
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 
 ADD release/linux/arm64/kaniko-gar /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gar"]

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.23.0
 
-ENV KANIKO_VERSION=1.20.1
+ENV KANIKO_VERSION=1.23.0
 ADD release/linux/amd64/kaniko-gcr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gcr"]


### PR DESCRIPTION
Upgrade Kaniko version that supports preserving permissions via the chmod argument on the Docker file.


<img width="1624" alt="Screenshot 2024-07-09 at 6 28 07 AM" src="https://github.com/drone/drone-kaniko/assets/67022814/a99f4952-9d32-400b-b0a1-2a3139a163c5">
<img width="1615" alt="Screenshot 2024-07-09 at 6 35 25 AM" src="https://github.com/drone/drone-kaniko/assets/67022814/b88c8c6b-ede3-4737-b0d2-2bb077ca3599">
