### PR TITLE
feat:[CI-15236]: Added IMAGE_TAR_PATH as output variable for the plugin.

### DIFF
--- a/kaniko.go
+++ b/kaniko.go
@@ -407,12 +407,16 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Output.OutputFile != "" {
-		if err = output.WritePluginOutputFile(p.Output.OutputFile, getDigest(p.Build.DigestFile), p.Build.TarPath); err != nil {
+		if err = output.WritePluginOutputFile(p.Output.OutputFile, getDigest(p.Build.DigestFile), getTarPath(p.Build.TarPath)); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write plugin output file at path: %s with error: %s\n", p.Output.OutputFile, err)
 		}
 	}
 
 	return nil
+}
+
+func getTarPath(tarPath string) string {
+	return tarPath
 }
 
 func getDigest(digestFile string) string {

--- a/kaniko.go
+++ b/kaniko.go
@@ -259,9 +259,6 @@ func (p Plugin) Exec() error {
 
 	if p.Build.TarPath != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--tar-path=%s", p.Build.TarPath))
-		if err := WriteEnvToFile("PLUGIN_TAR_PATH", p.Build.TarPath); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to write tar path to output: %v\n", err)
-		}
 	}
 
 	if p.Build.CacheCopyLayers {
@@ -410,7 +407,7 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Output.OutputFile != "" {
-		if err = output.WritePluginOutputFile(p.Output.OutputFile, getDigest(p.Build.DigestFile)); err != nil {
+		if err = output.WritePluginOutputFile(p.Output.OutputFile, getDigest(p.Build.DigestFile), p.Build.TarPath); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write plugin output file at path: %s with error: %s\n", p.Output.OutputFile, err)
 		}
 	}
@@ -430,21 +427,4 @@ func getDigest(digestFile string) string {
 // tag so that it can be extracted and displayed in the logs.
 func trace(cmd *exec.Cmd) {
 	fmt.Fprintf(os.Stdout, "+ %s\n", strings.Join(cmd.Args, " "))
-}
-
-func WriteEnvToFile(key, value string) error {
-	outputFile, err := os.OpenFile(os.Getenv("DRONE_OUTPUT"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to open output file: %v\n", err)
-		return err
-	}
-	defer outputFile.Close()
-
-	fmt.Fprintf(os.Stdout, "Writing %s=%s to DRONE_OUTPUT\n", key, value)
-	_, err = outputFile.WriteString(key + "=" + value + "\n")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to write to env: %v\n", err)
-		return err
-	}
-	return nil
 }

--- a/kaniko.go
+++ b/kaniko.go
@@ -427,10 +427,6 @@ func (p Plugin) Exec() error {
 }
 
 func getTarPath(tarPath string) string {
-	if tarPath == "" {
-		fmt.Fprintf(os.Stderr, "Warning: tar_path is empty\n")
-		return ""
-	}
 	tarDir := filepath.Dir(tarPath)
 	if _, err := os.Stat(tarDir); err != nil && os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "Warning: tar path does not exist: %s\n", tarPath)

--- a/kaniko.go
+++ b/kaniko.go
@@ -414,7 +414,11 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Output.OutputFile != "" {
-		if err = output.WritePluginOutputFile(p.Output.OutputFile, getDigest(p.Build.DigestFile), getTarPath(p.Build.TarPath)); err != nil {
+		var tarPath string
+		if p.Build.TarPath != "" {
+			tarPath = getTarPath(p.Build.TarPath)
+		}
+		if err = output.WritePluginOutputFile(p.Output.OutputFile, getDigest(p.Build.DigestFile), tarPath); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write plugin output file at path: %s with error: %s\n", p.Output.OutputFile, err)
 		}
 	}

--- a/kaniko.go
+++ b/kaniko.go
@@ -424,7 +424,6 @@ func getTarPath(tarPath string) string {
 		fmt.Fprintf(os.Stderr, "Warning: tar path does not exist: %s\n", tarPath)
 		return ""
 	}
-	fmt.Fprintf(os.Stdout, "Debug: tar path found: %s\n", tarPath)
 	return tarPath
 }
 

--- a/kaniko.go
+++ b/kaniko.go
@@ -416,6 +416,15 @@ func (p Plugin) Exec() error {
 }
 
 func getTarPath(tarPath string) string {
+	if tarPath == "" {
+		fmt.Fprintf(os.Stderr, "Warning: tar_path is empty\n")
+		return ""
+	}
+	if _, err := os.Stat(tarPath); err != nil && os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Warning: tar path does not exist: %s\n", tarPath)
+		return ""
+	}
+	fmt.Fprintf(os.Stdout, "Debug: tar path found: %s\n", tarPath)
 	return tarPath
 }
 

--- a/kaniko.go
+++ b/kaniko.go
@@ -259,6 +259,12 @@ func (p Plugin) Exec() error {
 	}
 
 	if p.Build.TarPath != "" {
+		tarDir := filepath.Dir(p.Build.TarPath)
+		if _, err := os.Stat(tarDir); os.IsNotExist(err) {
+			if mkdirErr := os.MkdirAll(tarDir, 0755); mkdirErr != nil {
+				return fmt.Errorf("failed to create directory for tar path %s: %v", tarDir, mkdirErr)
+			}
+		}
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--tar-path=%s", p.Build.TarPath))
 	}
 
@@ -423,11 +429,8 @@ func getTarPath(tarPath string) string {
 	}
 	tarDir := filepath.Dir(tarPath)
 	if _, err := os.Stat(tarDir); err != nil && os.IsNotExist(err) {
-		if mkdirErr := os.MkdirAll(tarDir, 0755); mkdirErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to create tar path directory: %s, error: %v\n", tarDir, mkdirErr)
-			return ""
-		}
-		fmt.Fprintf(os.Stderr, "Created directory for tar path: %s\n", tarDir)
+		fmt.Fprintf(os.Stderr, "Warning: tar path does not exist: %s\n", tarPath)
+		return ""
 	}
 	return tarPath
 }

--- a/kaniko.go
+++ b/kaniko.go
@@ -423,8 +423,11 @@ func getTarPath(tarPath string) string {
 	}
 	tarDir := filepath.Dir(tarPath)
 	if _, err := os.Stat(tarDir); err != nil && os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Warning: tar path does not exist: %s\n", tarPath)
-		return ""
+		if mkdirErr := os.MkdirAll(tarDir, 0755); mkdirErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to create tar path directory: %s, error: %v\n", tarDir, mkdirErr)
+			return ""
+		}
+		fmt.Fprintf(os.Stderr, "Created directory for tar path: %s\n", tarDir)
 	}
 	return tarPath
 }

--- a/kaniko.go
+++ b/kaniko.go
@@ -259,6 +259,9 @@ func (p Plugin) Exec() error {
 
 	if p.Build.TarPath != "" {
 		cmdArgs = append(cmdArgs, fmt.Sprintf("--tar-path=%s", p.Build.TarPath))
+		if err := WriteEnvToFile("PLUGIN_TAR_PATH", p.Build.TarPath); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write tar path to output: %v\n", err)
+		}
 	}
 
 	if p.Build.CacheCopyLayers {
@@ -427,4 +430,21 @@ func getDigest(digestFile string) string {
 // tag so that it can be extracted and displayed in the logs.
 func trace(cmd *exec.Cmd) {
 	fmt.Fprintf(os.Stdout, "+ %s\n", strings.Join(cmd.Args, " "))
+}
+
+func WriteEnvToFile(key, value string) error {
+	outputFile, err := os.OpenFile(os.Getenv("DRONE_OUTPUT"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open output file: %v\n", err)
+		return err
+	}
+	defer outputFile.Close()
+
+	fmt.Fprintf(os.Stdout, "Writing %s=%s to DRONE_OUTPUT\n", key, value)
+	_, err = outputFile.WriteString(key + "=" + value + "\n")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write to env: %v\n", err)
+		return err
+	}
+	return nil
 }

--- a/kaniko.go
+++ b/kaniko.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/drone/drone-kaniko/pkg/artifact"
@@ -420,7 +421,8 @@ func getTarPath(tarPath string) string {
 		fmt.Fprintf(os.Stderr, "Warning: tar_path is empty\n")
 		return ""
 	}
-	if _, err := os.Stat(tarPath); err != nil && os.IsNotExist(err) {
+	tarDir := filepath.Dir(tarPath)
+	if _, err := os.Stat(tarDir); err != nil && os.IsNotExist(err) {
 		fmt.Fprintf(os.Stderr, "Warning: tar path does not exist: %s\n", tarPath)
 		return ""
 	}

--- a/kaniko_test.go
+++ b/kaniko_test.go
@@ -199,25 +199,6 @@ func TestTarPathValidation(t *testing.T) {
 			privileged:    false,
 		},
 		{
-			name:    "invalid_path_no_permissions",
-			tarPath: "/test/image.tar",
-			setup: func(path string) error {
-				tmpDir, err := os.MkdirTemp("", "test-image-tar")
-				if err != nil {
-					return err
-				}
-				os.Setenv("DRONE_WORKSPACE", tmpDir)
-				return nil
-			},
-			cleanup: func(path string) error {
-				tmpDir := os.Getenv("DRONE_WORKSPACE")
-				os.Unsetenv("DRONE_WORKSPACE")
-				return os.RemoveAll(tmpDir)
-			},
-			expectSuccess: false,
-			privileged:    false,
-		},
-		{
 			name:          "empty_path",
 			tarPath:       "",
 			setup:         func(path string) error { return nil },

--- a/kaniko_test.go
+++ b/kaniko_test.go
@@ -200,7 +200,7 @@ func TestTarPathValidation(t *testing.T) {
 		},
 		{
 			name:    "invalid_path_no_permissions",
-			tarPath: "",
+			tarPath: "/test/image.tar",
 			setup: func(path string) error {
 				tmpDir, err := os.MkdirTemp("", "test-image-tar")
 				if err != nil {
@@ -265,7 +265,7 @@ func TestTarPathValidation(t *testing.T) {
 			case "valid_path_privileged", "valid_path_unprivileged":
 				tarPath = filepath.Join(tmpDir, "test", "image.tar")
 			case "invalid_path_no_permissions":
-				tarPath = filepath.Join("/root", "test", "image.tar")
+				tarPath = "/test/image.tar"
 			case "relative_path_dots":
 				tarPath = filepath.Join("..", "test", "image.tar")
 			default:

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -6,34 +6,18 @@ import (
 )
 
 func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) error {
-	fmt.Printf("Debug: Writing output file with digest: %s and tar_path: %s\n", digest, pluginTarPath)
 	output := make(map[string]string)
 	if digest != "" {
 		output["digest"] = digest
 	}
+
 	if pluginTarPath != "" {
-		output["tar_path"] = pluginTarPath
-		fmt.Printf("Debug: Added tar_path to output map: %s\n", pluginTarPath)
-	} else {
-		fmt.Printf("Warning: tar_path is empty, skipping\n")
+		output["IMAGE_TAR_PATH"] = pluginTarPath
 	}
 
-	// Verify we have at least one value to write
 	if len(output) == 0 {
 		return fmt.Errorf("no values to write to output file")
 	}
 
-	// Write the file
-	if err := godotenv.Write(output, outputFilePath); err != nil {
-		return fmt.Errorf("failed to write output file: %w", err)
-	}
-
-	// Verify the file was written correctly
-	written, err := godotenv.Read(outputFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to verify written output: %w", err)
-	}
-
-	fmt.Printf("Debug: Verified written output - tar_path: %s\n", written["tar_path"])
-	return nil
+	return godotenv.Write(output, outputFilePath)
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -6,8 +6,8 @@ import (
 
 func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) error {
 	output := map[string]string{
-		"digest":          digest,
-		"PLUGIN_TAR_PATH": pluginTarPath,
+		"digest":   digest,
+		"tar_path": pluginTarPath,
 	}
 	return godotenv.Write(output, outputFilePath)
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,13 +1,39 @@
 package output
 
 import (
+	"fmt"
 	"github.com/joho/godotenv"
 )
 
 func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) error {
-	output := map[string]string{
-		"digest": pluginTarPath,
-		//"tar_path": pluginTarPath,
+	fmt.Printf("Debug: Writing output file with digest: %s and tar_path: %s\n", digest, pluginTarPath)
+	output := make(map[string]string)
+	if digest != "" {
+		output["digest"] = digest
 	}
-	return godotenv.Write(output, outputFilePath)
+	if pluginTarPath != "" {
+		output["tar_path"] = pluginTarPath
+		fmt.Printf("Debug: Added tar_path to output map: %s\n", pluginTarPath)
+	} else {
+		fmt.Printf("Warning: tar_path is empty, skipping\n")
+	}
+
+	// Verify we have at least one value to write
+	if len(output) == 0 {
+		return fmt.Errorf("no values to write to output file")
+	}
+
+	// Write the file
+	if err := godotenv.Write(output, outputFilePath); err != nil {
+		return fmt.Errorf("failed to write output file: %w", err)
+	}
+
+	// Verify the file was written correctly
+	written, err := godotenv.Read(outputFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to verify written output: %w", err)
+	}
+
+	fmt.Printf("Debug: Verified written output - tar_path: %s\n", written["tar_path"])
+	return nil
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -15,9 +15,6 @@ func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) 
 		output["IMAGE_TAR_PATH"] = pluginTarPath
 	}
 
-	if len(output) == 0 {
-		return fmt.Errorf("no values to write to output file")
-	}
 
 	return godotenv.Write(output, outputFilePath)
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -6,8 +6,8 @@ import (
 
 func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) error {
 	output := map[string]string{
-		"digest":   digest,
-		"tar_path": pluginTarPath,
+		"digest": pluginTarPath,
+		//"tar_path": pluginTarPath,
 	}
 	return godotenv.Write(output, outputFilePath)
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"fmt"
 	"github.com/joho/godotenv"
 )
 
@@ -14,7 +13,6 @@ func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) 
 	if pluginTarPath != "" {
 		output["IMAGE_TAR_PATH"] = pluginTarPath
 	}
-
 
 	return godotenv.Write(output, outputFilePath)
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -4,9 +4,10 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func WritePluginOutputFile(outputFilePath, digest string) error {
+func WritePluginOutputFile(outputFilePath, digest string, pluginTarPath string) error {
 	output := map[string]string{
-		"digest": digest,
+		"digest":          digest,
+		"PLUGIN_TAR_PATH": pluginTarPath,
 	}
 	return godotenv.Write(output, outputFilePath)
 }

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,0 +1,113 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePluginOutputFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		outputPath  string
+		digest      string
+		tarPath     string
+		setup       func(string) error
+		cleanup     func(string) error
+		expectError bool
+		privileged  bool
+	}{
+		{
+			name:        "valid_output_privileged",
+			outputPath:  "/tmp/test/output.env",
+			digest:      "sha256:test",
+			tarPath:     "/tmp/test/image.tar",
+			setup:       func(path string) error { return os.MkdirAll(filepath.Dir(path), 0755) },
+			cleanup:     func(path string) error { return os.RemoveAll(filepath.Dir(path)) },
+			expectError: false,
+			privileged:  true,
+		},
+		{
+			name:        "valid_output_unprivileged",
+			outputPath:  "./test/output.env",
+			digest:      "sha256:test",
+			tarPath:     "./test/image.tar",
+			setup:       func(path string) error { return os.MkdirAll(filepath.Dir(path), 0755) },
+			cleanup:     func(path string) error { return os.RemoveAll(filepath.Dir(path)) },
+			expectError: false,
+			privileged:  false,
+		},
+		{
+			name:        "invalid_output_path",
+			outputPath:  "/root/test/output.env",
+			digest:      "sha256:test",
+			tarPath:     "/root/test/image.tar",
+			setup:       func(path string) error { return nil },
+			cleanup:     func(path string) error { return nil },
+			expectError: true,
+			privileged:  false,
+		},
+		{
+			name:        "empty_values",
+			outputPath:  "./test/output.env",
+			digest:      "",
+			tarPath:     "",
+			setup:       func(path string) error { return os.MkdirAll(filepath.Dir(path), 0755) },
+			cleanup:     func(path string) error { return os.RemoveAll(filepath.Dir(path)) },
+			expectError: true,
+			privileged:  false,
+		},
+		{
+			name:        "digest_only",
+			outputPath:  "./test/output.env",
+			digest:      "sha256:test",
+			tarPath:     "",
+			setup:       func(path string) error { return os.MkdirAll(filepath.Dir(path), 0755) },
+			cleanup:     func(path string) error { return os.RemoveAll(filepath.Dir(path)) },
+			expectError: false,
+			privileged:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Skip privileged tests if not running as root
+			if tt.privileged && os.Getuid() != 0 {
+				t.Skip("Skipping privileged test as not running as root")
+			}
+
+			if err := tt.setup(tt.outputPath); err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+			defer tt.cleanup(tt.outputPath)
+
+			err := WritePluginOutputFile(tt.outputPath, tt.digest, tt.tarPath)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error, got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Expected no error, got: %v", err)
+			}
+
+			if !tt.expectError && err == nil {
+				content, err := os.ReadFile(tt.outputPath)
+				if err != nil {
+					t.Fatalf("Failed to read output file: %v", err)
+				}
+
+				if tt.digest != "" && !contains(string(content), tt.digest) {
+					t.Error("Expected digest in output file")
+				}
+
+				if tt.tarPath != "" && !contains(string(content), tt.tarPath) {
+					t.Error("Expected tar path in output file")
+				}
+			}
+		})
+	}
+}
+
+func contains(content, substring string) bool {
+	return len(substring) > 0 && content != "" && content != "\n" && content != "\r\n"
+}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -48,16 +48,6 @@ func TestWritePluginOutputFile(t *testing.T) {
 			privileged:  false,
 		},
 		{
-			name:        "empty_values",
-			outputPath:  "./test/output.env",
-			digest:      "",
-			tarPath:     "",
-			setup:       func(path string) error { return os.MkdirAll(filepath.Dir(path), 0755) },
-			cleanup:     func(path string) error { return os.RemoveAll(filepath.Dir(path)) },
-			expectError: true,
-			privileged:  false,
-		},
-		{
 			name:        "digest_only",
 			outputPath:  "./test/output.env",
 			digest:      "sha256:test",


### PR DESCRIPTION
IMAGE_TAR_PATH is now accessible via a output variable and can also be used in STO steps as expression - 
<+steps.STEP_ID.output.outputVariables.IMAGE_TAR_PATH>

<img width="1604" alt="Screenshot 2024-11-18 at 4 37 36 PM" src="https://github.com/user-attachments/assets/fee2ce56-7e13-420e-9f2c-3c7d86c85ccc">