### PR TITLE
feat: [CI-16392]: Authenticate And Pull Private Base Images when NO_PUSH is enabled

### DIFF
--- a/cmd/kaniko-acr/main.go
+++ b/cmd/kaniko-acr/main.go
@@ -487,7 +487,7 @@ func setupAuth(tenantId, clientId, cert,
 		token, publicUrl, err := getACRToken(subscriptionId, tenantId, clientId, clientSecret, cert, registry)
 		if err != nil {
 			if noPush {
-				logrus.Warnf("failed to fetch ACR Token: %v", err)
+				logrus.Warnf("NO_PUSH mode: failed to fetch ACR Token: %v", err)
 				return "", nil
 			}
 			return "", errors.Wrap(err, "failed to fetch ACR Token")
@@ -496,7 +496,7 @@ func setupAuth(tenantId, clientId, cert,
 		// setup docker config for azure registry and base image docker registry
 		if err := setDockerAuth(username, token, registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
 			if noPush {
-				logrus.Warnf("failed to create docker config: %v", err)
+				logrus.Warnf("NO_PUSH mode: failed to create docker config: %v", err)
 				return "", nil
 			}
 			return "", errors.Wrap(err, "failed to create docker config")
@@ -504,7 +504,6 @@ func setupAuth(tenantId, clientId, cert,
 		return publicUrl, nil
 	} else {
 		if noPush {
-			logrus.Warn("managed authentication is not supported")
 			return "", nil
 		}
 		return "", fmt.Errorf("managed authentication is not supported")

--- a/cmd/kaniko-acr/main.go
+++ b/cmd/kaniko-acr/main.go
@@ -486,19 +486,30 @@ func setupAuth(tenantId, clientId, cert,
 
 		token, publicUrl, err := getACRToken(subscriptionId, tenantId, clientId, clientSecret, cert, registry)
 		if err != nil {
+			if noPush {
+				logrus.Warnf("failed to fetch ACR Token: %v", err)
+				return "", nil
+			}
 			return "", errors.Wrap(err, "failed to fetch ACR Token")
 		}
 
 		// setup docker config for azure registry and base image docker registry
 		if err := setDockerAuth(username, token, registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
+			if noPush {
+				logrus.Warnf("failed to create docker config: %v", err)
+				return "", nil
+			}
 			return "", errors.Wrap(err, "failed to create docker config")
 		}
 		return publicUrl, nil
 	} else {
+		if noPush {
+			logrus.Warn("managed authentication is not supported")
+			return "", nil
+		}
 		return "", fmt.Errorf("managed authentication is not supported")
 	}
 }
-
 
 func getACRToken(subscriptionId, tenantId, clientId, clientSecret, cert, registry string) (string, string, error) {
 	if tenantId == "" {

--- a/cmd/kaniko-acr/main.go
+++ b/cmd/kaniko-acr/main.go
@@ -498,8 +498,8 @@ func setupAuth(tenantId, clientId, cert,
 		}
 	} else {
 		// When no-push is enabled, we still need to set up pull credentials.
-		// We do not fetch a token (since we are not pushing) so we pass an empty string for push credentials.
-		if err := setDockerAuth(username, "", registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
+		// If no push, we set the push credentials to empty values and still pull the base image using the provided credentials.
+		if err := setDockerAuth("", "", registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
 			return "", errors.Wrap(err, "failed to create docker config for pulling base image")
 		}
 		return "", nil

--- a/cmd/kaniko-acr/main.go
+++ b/cmd/kaniko-acr/main.go
@@ -480,26 +480,29 @@ func setupAuth(tenantId, clientId, cert,
 		return "", fmt.Errorf("registry must be specified")
 	}
 
-	if noPush {
-		return "", nil
-	}
+	if !noPush {
+		// When pushing is enabled, do the full token-based authentication.
+		if clientId != "" {
+			token, publicUrl, err := getACRToken(subscriptionId, tenantId, clientId, clientSecret, cert, registry)
+			if err != nil {
+				return "", errors.Wrap(err, "failed to fetch ACR Token")
+			}
 
-	// case of client secret or cert based auth
-	if clientId != "" {
-		// only setup auth when pushing or credentials are defined
-
-		token, publicUrl, err := getACRToken(subscriptionId, tenantId, clientId, clientSecret, cert, registry)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to fetch ACR Token")
+			// Set up docker config with credentials for both push and pull.
+			if err := setDockerAuth(username, token, registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
+				return "", errors.Wrap(err, "failed to create docker config")
+			}
+			return publicUrl, nil
+		} else {
+			return "", fmt.Errorf("managed authentication is not supported")
 		}
-
-		// setup docker config for azure registry and base image docker registry
-		if err := setDockerAuth(username, token, registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
-			return "", errors.Wrap(err, "failed to create docker config")
-		}
-		return publicUrl, nil
 	} else {
-		return "", fmt.Errorf("managed authentication is not supported")
+		// When no-push is enabled, we still need to set up pull credentials.
+		// We do not fetch a token (since we are not pushing) so we pass an empty string for push credentials.
+		if err := setDockerAuth(username, "", registry, dockerUsername, dockerPassword, dockerRegistry); err != nil {
+			return "", errors.Wrap(err, "failed to create docker config for pulling base image")
+		}
+		return "", nil
 	}
 }
 


### PR DESCRIPTION
This update refines the setupAuth function in the drone-kaniko plugin to improve backward compatibility and clarify error handling for NO_PUSH mode.
- Error Handling: When `NO_PUSH` is enabled, if fetching the ACR token or creating the Docker config fails, the function now logs a warning (prefixed with `“NO_PUSH mode:”`) and continues instead of returning an error. This ensures that builds pulling public images are not blocked by missing auth credentials.
- Push Mode Behavior: In push mode, the function behaves as before, errors in fetching the token or setting up Docker auth are returned, halting the build.
- Managed Auth Check: If managed authentication isn’t supported (i.e., when clientId is not provided), an error is returned unless in `NO_PUSH` mode, in which case it returns silently.

This change makes the plugin more resilient in `NO_PUSH` scenarios while preserving the expected behavior for pushes.

Test Executions confirming the changes: Private Base [NO_PUSH](https://app.harness.io/ng/account/fjf_VfuITK2bBrMLg5xV7g/module/cd/orgs/default/projects/GlobalCorp/pipelines/OrdersApinopush/executions/-1M5rPkcSmWt_74BzZ085A/pipeline) & [PUSH](https://app.harness.io/ng/account/fjf_VfuITK2bBrMLg5xV7g/module/cd/orgs/default/projects/GlobalCorp/pipelines/OrdersApinopush/executions/PHJQvVIYS067Kq5Yo1JwyA/pipeline), Public Base [NO_PUSH](https://app.harness.io/ng/account/fjf_VfuITK2bBrMLg5xV7g/module/cd/orgs/default/projects/GlobalCorp/pipelines/OrdersApinopush/executions/GyKJ__htTcSjCGzwt5y9Mg/pipeline) & [PUSH](https://app.harness.io/ng/account/fjf_VfuITK2bBrMLg5xV7g/module/cd/orgs/default/projects/GlobalCorp/pipelines/OrdersApinopush/executions/wyr8LJyYTwO2OLuAfnsJPA/pipeline)