### PR TITLE
feat: [CI-16588]: Add support to PLUGIN_TAR_PATH, PLUGIN_SOURCE_TAR_PATH and PLUGIN_PUSH_ONLY to kaniko-ecr

### DIFF
--- a/cmd/kaniko-ecr/main.go
+++ b/cmd/kaniko-ecr/main.go
@@ -403,6 +403,21 @@ func main() {
 			Usage:  "OIDC token for assuming role via web identity",
 			EnvVar: "PLUGIN_OIDC_TOKEN_ID",
 		},
+		cli.StringFlag{
+			Name:   "tar-path",
+			Usage:  "Set this flag to save the image as a tarball at path",
+			EnvVar: "PLUGIN_TAR_PATH, PLUGIN_DESTINATION_TAR_PATH",
+		},
+		cli.StringFlag{
+			Name:   "source-tar-path",
+			Usage:  "Set this flag for the source tarball during push operations.",
+			EnvVar: "PLUGIN_SOURCE_TAR_PATH",
+		},
+		cli.BoolFlag{
+			Name:   "push-only",
+			Usage:  "Specify if the operation is push-only",
+			EnvVar: "PLUGIN_PUSH_ONLY",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -521,6 +536,9 @@ func run(c *cli.Context) error {
 			IgnorePaths:                 c.StringSlice("ignore-paths"),
 			ImageFSExtractRetry:         c.Int("image-fs-extract-retry"),
 			ImageDownloadRetry:          c.Int("image-download-retry"),
+			TarPath:                     c.String("tar-path"),
+			SourceTarPath:               c.String("source-tar-path"),
+			PushOnly:                    c.Bool("push-only"),
 		},
 		Artifact: kaniko.Artifact{
 			Tags:         c.StringSlice("tags"),


### PR DESCRIPTION
This PR adds three new flags to enhance the plugin's image handling capabilities:

1. PLUGIN_PUSH_ONLY - Enables pushing pre-built image tarball without running a build

2. PLUGIN_SOURCE_TAR_PATH - Used in conjunction with push-only mode

3. PLUGIN_TAR_PATH, PLUGIN_DESTINATION_TAR_PATH - Provides consistent naming with source-tar-path

These additions enable more flexible workflows by allowing separation of build and push operations
[Test execution link with Access and Secret Key](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/CI16588kanikoecrtarpath/deployments/tYFW01U6Shae47KElSeqvQ/pipeline?storeType=INLINE)
[Test execution link with OIDC](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/Ansibler/projects/Automate/pipelines/CI16588kanikoecrtarpath/executions/cwQv3YZvSDmPrTUMbgGZfQ/pipeline?storeType=INLINE)