### PR TITLE
feat: [CI-10849]: Switch to Chainguard-maintained Kaniko images after Google archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Drone kaniko plugin uses [kaniko](https://github.com/GoogleContainerTools/kaniko
 
 Plugin images are published with 1.6.0 as well as 1.9.1 kaniko version from 1.5.1 release tag. `plugins/kaniko:<release-tag>` uses 1.6.0 version while `plugins/kaniko:<release-tag>-kaniko1.9.1` uses 1.9.1 version. Similar convention is used for plugins/kaniko-ecr & plugins/kaniko-gcr images as well.
 
+Run the following script to install git-leaks support to this repo.
+```
+chmod +x ./git-hooks/install.sh
+./git-hooks/install.sh
+```
+
 ## Build
 
 Build the binaries with the following commands:

--- a/git-hooks/.gitleaksignore
+++ b/git-hooks/.gitleaksignore
@@ -1,4 +1,0 @@
-#For More Info: https://github.com/zricethezav/gitleaks/blob/master/.gitleaksignore
-
-#CommitID:FilePath:TypeOfSecret:LineNumber
-aee83e4f314e220afbf237a39d6520e292823d6e:batch-processing/service/src/test/java/io/harness/batch/processing/anomalydetection/AnomalyAlertsServiceImplTest.java:slack-web-hook:57

--- a/git-hooks/.gitleaksignore
+++ b/git-hooks/.gitleaksignore
@@ -1,0 +1,4 @@
+#For More Info: https://github.com/zricethezav/gitleaks/blob/master/.gitleaksignore
+
+#CommitID:FilePath:TypeOfSecret:LineNumber
+aee83e4f314e220afbf237a39d6520e292823d6e:batch-processing/service/src/test/java/io/harness/batch/processing/anomalydetection/AnomalyAlertsServiceImplTest.java:slack-web-hook:57

--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -1,0 +1,8 @@
+This document explains on how to install certain git hooks globally for all repositories in your machine.
+
+Step 1: git clone https://github.com/wings-software/build-tools-utility.git
+Step 2: cd git-hooks
+Step 3: Run install.sh
+
+"install.sh" script will create .git_template in the user directory and will put the git hook and its dependent scripts in it. Along with the .git_template folder, it will add 2 sections "init" and "hooks boolean" in the .gitconfig file in the same user's root directory.
+After running "install.sh" if you create/clone a new git repository then all the hooks will get install automatically for the git repository. In case of existing git repository copy the contents of ~/.git_template/hooks into the .git/hooks directory of existing git repository.

--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -1,6 +1,6 @@
 This document explains on how to install certain git hooks globally for all repositories in your machine.
 
-Step 1: git clone https://github.com/wings-software/build-tools-utility.git
+Step 1: git clone https://github.com/drone/drone-kaniko.git
 Step 2: cd git-hooks
 Step 3: Run install.sh
 

--- a/git-hooks/hooks/git-leaks-pre-commit.sh
+++ b/git-hooks/hooks/git-leaks-pre-commit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#Helper script to be used as a pre-commit hook.
+
+echo "This hook checks for any secrets getting pushed as part of commit. If you feel that scan is false positive. \
+Then add the exclusion in .gitleaksignore file. For more info visit: https://github.com/zricethezav/gitleaks"
+
+GIT_LEAKS_PRE_COMMIT=s$(git config --bool hook.pre-commit.gitleak)
+
+echo "INFO: Scanning Commits information for any GIT LEAKS"
+gitleaks protect --staged -v --exit-code=100
+STATUS=$?
+if [ $STATUS = 100  ]; then
+    echo "WARNING: GIT LEAKS has detected sensitive information in your changes. Please remove them or add them (IF NON-SENSITIVE) in .gitleaksignore file."
+else
+    exit 0
+fi

--- a/git-hooks/hooks/git-leaks.sh
+++ b/git-hooks/hooks/git-leaks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#Helper script to be used as a pre-commit hook.
+
+echo "This hook checks for any secrets getting pushed as part of commit. If you feel that scan is false positive. \
+Then add the exclusion in .gitleaksignore file. For more info visit: https://github.com/zricethezav/gitleaks"
+
+GIT_LEAKS=$(git config --bool hook.pre-push.gitleaks)
+
+echo "INFO: Scanning Commits information for any GIT LEAKS"
+gitleaks detect -s ./ --log-level=debug --log-opts=-1 -v
+STATUS=$?
+if [ $STATUS != 0  ]; then
+    echo "WARNING: GIT LEAKS has detected sensitive information in your changes. Please remove them or add them (IF NON-SENSITIVE) in .gitleaksignore file."
+    exit $STATUS
+else
+    exit 0
+fi

--- a/git-hooks/hooks/pre-commit
+++ b/git-hooks/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+GL_SCRIPT_PATH="$HOME/.git_template/hooks/git-leaks-pre-commit.sh"
+
+pushd `dirname $0` > /dev/null && cd ../.. && BASEDIR=$(pwd -L) && popd > /dev/null
+BASENAME=`basename $0`
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    #Initial commit : diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+GIT_LEAKS_PRE_COMMIT=hook.pre-commit.gitleaks
+if [ "`git config $GIT_LEAKS_PRE_COMMIT`" == "false" ]
+then
+    echo -e '\033[0;31m' checking git leaks is disabled - to enable: '\033[0;37m'git config --unset $GIT_LEAKS_PRE_COMMIT '\033[0m'
+    echo -e '\033[0;34m' checking git leaks  ... to enable: '\033[0;37m'git config --add $GIT_LEAKS_PRE_COMMIT true '\033[0m'
+else
+    echo -e '\033[0;34m' checking for git leaks...
+    [ -f "${GL_SCRIPT_PATH}" ] && . ${GL_SCRIPT_PATH} || echo "ERROR: Hook Script Not Found..." && exit 404
+fi

--- a/git-hooks/hooks/pre-push
+++ b/git-hooks/hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+GL_SCRIPT_PATH="$HOME/.git_template/hooks/git-leaks.sh"
+
+pushd `dirname $0` > /dev/null && cd ../.. && BASEDIR=$(pwd -L) && popd > /dev/null
+BASENAME=`basename $0`
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    #Initial commit : diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+GIT_LEAKS=hook.pre-push.gitleaks
+if [ "`git config $GIT_LEAKS`" == "false" ]
+then
+    echo -e '\033[0;31m' checking git leaks is disabled - to enable: '\033[0;37m'git config --unset $GIT_LEAKS '\033[0m'
+    echo -e '\033[0;34m' checking git leaks  ... to enable: '\033[0;37m'git config --add $GIT_LEAKS true '\033[0m'
+else
+    echo -e '\033[0;34m' checking for git leaks...
+    [ -f "${GL_SCRIPT_PATH}" ] && . ${GL_SCRIPT_PATH} || echo "ERROR: Hook Script Not Found..." && exit 404
+fi

--- a/git-hooks/install.sh
+++ b/git-hooks/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+#Function to check if package is installed or not
+#args: $1: Name of the Package
+function check_package_installed() {
+  LOCAL_PACKAGE_NAME=$1
+  echo "Checking if $LOCAL_PACKAGE_NAME is installed or not..."
+  brew list $LOCAL_PACKAGE_NAME
+  if [ "$?" -eq 1 ];then
+    echo "Installing $LOCAL_PACKAGE_NAME package..."
+    brew install $LOCAL_PACKAGE_NAME
+  fi
+}
+
+function create_git_template() {
+    cd $BASEDIR
+    mkdir -p ~/.git_template/hooks
+    git config --global init.templatedir ${GIT_TEMPLATE}
+    git config --global --add $GIT_LEAKS true
+    git config --global --add $GIT_LEAKS_PRE_COMMIT true
+    find hooks/ -type f -exec cp "{}" ~/.git_template/hooks \;
+    #cp -f hooks/* ~/.git_template/hooks
+    cat ~/.gitconfig
+}
+
+GIT_TEMPLATE="~/.git_template"
+GIT_LEAKS=hook.pre-push.gitleaks
+GIT_LEAKS_PRE_COMMIT=hook.pre-commit.gitleaks
+
+pushd `dirname $0` && BASEDIR=$(pwd -L) && popd
+
+echo This script will install hooks that run scripts that could be updated without notice.
+
+while true; do
+    read -p "Do you wish to install these hooks?" yn
+    case $yn in
+        [Yy]* ) check_package_installed "gitleaks";
+                break;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+create_git_template


### PR DESCRIPTION
Updated our kaniko-executor images to use Chainguard's maintained fork of Kaniko since Google has archived the original project. This ensures continued support and security updates for our drone-kaniko-plugins.

### Changes
- Replaced Google's kaniko images with builds from Chainguard's maintained fork
- Updated Docker build configurations for all supported platforms (amd64/arm64)
- Applied changes across all registry types (ACR, Docker Hub, ECR)

### Motivation
Google has archived the Kaniko project, making Chainguard's fork the most actively maintained option for continued use and security updates.