### PR TITLE
feat: [CI-18100]: Switch to Chainguard-maintained Kaniko images after Google archival

### DIFF
--- a/docker/acr/Dockerfile.linux.amd64
+++ b/docker/acr/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-amd64
 
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 ADD release/linux/amd64/kaniko-acr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-acr"]

--- a/docker/acr/Dockerfile.linux.arm64
+++ b/docker/acr/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.23.0
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-arm64
 
 ENV HOME /root
 ENV USER root
 
-ENV KANIKO_VERSION=1.23.0
+ENV KANIKO_VERSION=1.25.0
 ADD release/linux/arm64/kaniko-acr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-acr"]

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-amd64
 
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 ADD release/linux/amd64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-arm64
 
 ENV HOME /root
 ENV USER root
 
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 ADD release/linux/arm64/kaniko-docker /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-docker"]

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-amd64
 
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 ADD release/linux/amd64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/ecr/Dockerfile.linux.arm64
+++ b/docker/ecr/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-arm64
 
 ENV HOME /root
 ENV USER root
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 
 ADD release/linux/arm64/kaniko-ecr /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-ecr"]

--- a/docker/gar/Dockerfile.linux.amd64
+++ b/docker/gar/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-amd64
 
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 ADD release/linux/amd64/kaniko-gar /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gar"]

--- a/docker/gar/Dockerfile.linux.arm64
+++ b/docker/gar/Dockerfile.linux.arm64
@@ -1,8 +1,8 @@
-FROM gcr.io/kaniko-project/executor:v1.23.2
+FROM harnesscommunity/kaniko-executor:1.25.0-linux-arm64
 
 ENV HOME /root
 ENV USER root
-ENV KANIKO_VERSION=1.23.2
+ENV KANIKO_VERSION=1.25.0
 
 ADD release/linux/arm64/kaniko-gar /kaniko/
 ENTRYPOINT ["/kaniko/kaniko-gar"]


### PR DESCRIPTION
#### Summary
Updated our kaniko-executor images to use Chainguard's maintained fork of Kaniko since Google has archived the original project. This ensures continued support and security updates for our drone-kaniko-plugins.

#### Changes
- Replaced Google's kaniko images with builds from Chainguard's maintained fork
- Updated Docker build configurations for all supported platforms (amd64/arm64)
- Applied changes across all registry types (ACR, Docker Hub, ECR)

#### Motivation
Google has archived the Kaniko project, making Chainguard's fork the most actively maintained option for continued use and security updates.