### PR TITLE
fix: [CI-23227] bump Go toolchain to 1.25.11 to remediate kaniko-docker stdlib CVEs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ platform:
 
 steps:
 - name: build
-  image: golang:1.22.4
+  image: golang:1.25.11
   commands:
   - go test ./...
   - sh scripts/build.sh
@@ -178,7 +178,7 @@ pool:
 
 steps:
 - name: build
-  image: golang:1.22.4
+  image: golang:1.25.11
   commands:
   - go test ./...
   - sh scripts/build.sh

--- a/.harness/harness.yaml
+++ b/.harness/harness.yaml
@@ -37,7 +37,7 @@ pipeline:
                       identifier: Build
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.7
+                        image: golang:1.25.11
                         shell: Sh
                         command: |-
                           go test ./...
@@ -322,7 +322,7 @@ pipeline:
                       identifier: Build_and_Test
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.7
+                        image: golang:1.25.11
                         shell: Sh
                         command: |-
                           go test ./...
@@ -618,7 +618,7 @@ pipeline:
                       identifier: build_binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.7
+                        image: golang:1.25.11
                         shell: Sh
                         command: |-
                           go test ./...
@@ -923,7 +923,7 @@ pipeline:
                       identifier: build_binary
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.7
+                        image: golang:1.25.11
                         shell: Sh
                         command: |-
                           go test ./...

--- a/.harness/orgs/default/projects/Drone_Plugins/pipelines/dronekanikoharness_Clone.yaml
+++ b/.harness/orgs/default/projects/Drone_Plugins/pipelines/dronekanikoharness_Clone.yaml
@@ -35,7 +35,7 @@ pipeline:
                       identifier: Build
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.7
+                        image: golang:1.25.11
                         shell: Sh
                         command: |-
                           go test ./...
@@ -320,7 +320,7 @@ pipeline:
                       identifier: Build_and_Test
                       spec:
                         connectorRef: Plugins_Docker_Hub_Connector
-                        image: golang:1.25.7
+                        image: golang:1.25.11
                         shell: Sh
                         command: |-
                           go test ./...

--- a/go.mod
+++ b/go.mod
@@ -58,4 +58,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.7
+go 1.25.11


### PR DESCRIPTION
## Vulnerability Remediation: harnesssecure/kaniko

**Team:** ci (Harness CI Platform)
**Tickets:** [CI-23227](https://harness.atlassian.net/browse/CI-23227)
**Test image:** `vinayakharness/kaniko-test:kaniko-1.13.9--debug`

**OnDemand scanner runs (Harness https://harness0.harness.io/):**
- Baseline: [5obvJjkOQEyhoLSAmL6caw](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/5obvJjkOQEyhoLSAmL6caw/pipeline)
- After:    [Xqqc-gsnTZKjr0rjjP9DfQ](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/Xqqc-gsnTZKjr0rjjP9DfQ/pipeline)

---

### Summary

Upgrading the Go toolchain from 1.25.7 to **1.25.11** for drone-kaniko's binaries fully clears every stdlib CVE that Trivy flagged in our `kaniko-docker` binary (20/20 CVEs resolved, 0 new). Trivy's overall image delta is **81 → 61 (−20)** with no new CVEs introduced. The 36 vulnerabilities still present all live in the bundled binaries shipped by the `harnesscommunity/kaniko-executor:1.25.15` base image — `executor`, `docker-credential-acr-env`, `docker-credential-ecr-login`, `docker-credential-gcr` — and are upstream-blocked: 1.25.15 is currently the only patch version published in that repo, so they cannot be remediated from drone-kaniko alone. Recommendation: **REVIEW** — ship the Go bump now, track the kaniko-executor base-image bumps as a follow-up against the `harnesscommunity/kaniko-executor` publisher.

---

### CVE Delta — Trivy (local scan)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 0      | 0     | 0      |
| High     | 52     | 39    | -13    |
| Medium   | 27     | 21    | -6     |
| Low      | 2      | 1     | -1     |
| Total    | 81     | 61    | -20    |

#### Per-binary breakdown (Trivy)

| Binary | Before (C/H/M/L) | After (C/H/M/L) |
|---|---|---|
| `kaniko/kaniko-docker` (built here) | 0 / 13 / 6 / 1 | **0 / 0 / 0 / 0** |
| `kaniko/executor` (base image)      | 0 / 25 / 13 / 1 | 0 / 25 / 13 / 1 |
| `kaniko/docker-credential-acr-env` (base image) | 0 / 10 / 6 / 0 | 0 / 10 / 6 / 0 |
| `kaniko/docker-credential-ecr-login` (base image) | 0 / 2 / 1 / 0 | 0 / 2 / 1 / 0 |
| `kaniko/docker-credential-gcr` (base image) | 0 / 2 / 1 / 0 | 0 / 2 / 1 / 0 |

### CVE Delta — Harness OnDemand (Prisma Cloud)

The OnDemand scanner runs above are linked for reviewer verification. STO API counts couldn't be programmatically pulled in this run; please consult the linked executions for Prisma Cloud counts.

---

### Per-Ticket CVE Status

#### CI-23227 — [P2: Security Vulnerability Fixes - harnesssecure/kaniko](https://harness.atlassian.net/browse/CI-23227)

The ticket reports an aggregate snapshot (no specific CVE list). The remediation targets every CVE in our self-built `kaniko-docker` binary; everything else lives in the base image.

**Resolved in our binary (20/20):**

| CVE | Package | Before | After | Required | Status |
|-----|---------|--------|-------|----------|--------|
| CVE-2026-25679 | stdlib | v1.25.7 | (gone) | 1.25.8 / 1.26.1 | OK |
| CVE-2026-27139 | stdlib | v1.25.7 | (gone) | 1.25.8 / 1.26.1 | OK |
| CVE-2026-27142 | stdlib | v1.25.7 | (gone) | 1.25.8 / 1.26.1 | OK |
| CVE-2026-27145 | stdlib | v1.25.7 | (gone in our binary) | 1.25.11 / 1.26.4 | OK |
| CVE-2026-32280 | stdlib | v1.25.7 | (gone) | 1.25.9 / 1.26.2 | OK |
| CVE-2026-32281 | stdlib | v1.25.7 | (gone) | 1.25.9 / 1.26.2 | OK |
| CVE-2026-32282 | stdlib | v1.25.7 | (gone) | 1.25.9 / 1.26.2 | OK |
| CVE-2026-32283 | stdlib | v1.25.7 | (gone) | 1.25.9 / 1.26.2 | OK |
| CVE-2026-32288 | stdlib | v1.25.7 | (gone) | 1.25.9 / 1.26.2 | OK |
| CVE-2026-32289 | stdlib | v1.25.7 | (gone) | 1.25.9 / 1.26.2 | OK |
| CVE-2026-33811 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-33814 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-39820 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-39823 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-39825 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-39826 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-39836 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-42499 | stdlib | v1.25.7 | (gone) | 1.25.10 / 1.26.3 | OK |
| CVE-2026-42504 | stdlib | v1.25.7 | (gone in our binary) | 1.25.11 / 1.26.4 | OK |
| CVE-2026-42507 | stdlib | v1.25.7 | (gone in our binary) | 1.25.11 / 1.26.4 | OK |

**BLOCKED — base-image-bundled binaries from `harnesscommunity/kaniko-executor:1.25.15`** (cannot be fixed in drone-kaniko; need a re-published kaniko-executor):

| CVE | Affected binaries | Package | Reason |
|-----|-------------------|---------|--------|
| CVE-2026-27145, CVE-2026-42504, CVE-2026-42507 | executor + 3 cred helpers | stdlib v1.26.3 | 1.25.15 base built with Go 1.26.3, fix in 1.26.4 — no newer base tag published |
| CVE-2026-25680, -25681, -27136, -39821, -42502, -42506 | executor | golang.org/x/net v0.53.0 → 0.55.0 | base image dep |
| CVE-2026-39827–30, -39831–34, -39835, -42508, -46595, -46597, -46598 | executor + acr-env | golang.org/x/crypto v0.50.0 → 0.52.0 | base image dep |
| CVE-2026-46680, -47262, -50195, -53488, -53489, -53492 | executor | github.com/containerd/containerd v1.7.31, v2.2.2 | base image dep |
| CVE-2026-33997, -34040, -41567, -41568, -42306 | executor | github.com/docker/docker v28.5.2 | base image dep (some have no upstream fix yet) |
| CVE-2026-45570, -45571, GHSA-w5pp-99ch-qj29 | executor | github.com/go-git/go-git/v5 v5.19.0 → 5.19.1 | base image dep |

---

### Changes Made

| File | Change |
|------|--------|
| `go.mod` | `go 1.25.7` → `go 1.25.11` (toolchain bump) |
| `.drone.yml` | `golang:1.22.4` → `golang:1.25.11` (build image, both `default` and `harness` pipelines) |
| `.harness/harness.yaml` | `golang:1.25.7` → `golang:1.25.11` (4 build steps) |
| `.harness/orgs/default/projects/Drone_Plugins/pipelines/dronekanikoharness_Clone.yaml` | `golang:1.25.7` → `golang:1.25.11` (2 build steps) |

**Version selection rationale:**
- **Go 1.25.11** chosen as the *minimum* safe patch in the existing `1.25.x` line that fixes every stdlib CVE Trivy flags in our `kaniko-docker` binary. Trivy's strictest requirement is `1.25.11` (CVE-2026-27145, CVE-2026-42504, CVE-2026-42507); 1.25.11 is a patch-only bump from 1.25.7 and avoids crossing into Go 1.26 unnecessarily.
- The `harnesscommunity/kaniko-executor` base image stays at `1.25.15-linux-{amd64,arm64}` — the latest tag the publisher has shipped. No newer tag is available on Docker Hub at the time of this PR.

---

### Newly Introduced CVEs

None. Every CVE in the after-scan was also in the baseline.

---

### Test image

The test image `vinayakharness/kaniko-test:kaniko-1.13.9--debug` was built from this branch using the same multi-stage strategy as the production Dockerfiles (`golang:1.25.11` builder → `harnesscommunity/kaniko-executor:1.25.15-linux-amd64` runtime). The build pipeline in this repo will produce equivalent images on merge.

🤖 Vuln-remediation agent — opened as **DRAFT**; humans review at PR time.


[CI-23227]: https://harness.atlassian.net/browse/CI-23227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ